### PR TITLE
Fix: Add missing prometheus_client package

### DIFF
--- a/auto_builder.sh
+++ b/auto_builder.sh
@@ -114,10 +114,23 @@ case $value in
 
     2) ######################################################################################
         set -x
+        if [ ! -f $working_directory/sources/prometheus_client-$prometheus_client_version.tar.gz ]; then
+            wget -P $working_directory/sources/ https://github.com/prometheus/client_python/archive/v$prometheus_client_version.tar.gz
+            mv $working_directory/sources/v$prometheus_client_version.tar.gz $working_directory/sources/prometheus_client-$prometheus_client_version.tar.gz
+        fi
+        rm -Rf $working_directory/build/prometheus
+        mkdir -p $working_directory/build/prometheus
+        cd $working_directory/build/prometheus
+        cp $working_directory/sources/prometheus_client-$prometheus_client_version.tar.gz .
+        tar xvzf prometheus_client-$prometheus_client_version.tar.gz
+        cd client_python-$prometheus_client_version
+        python setup.py bdist_rpm --spec-only
+        cd ..
+        mv client_python-$prometheus_client_version prometheus_client-$prometheus_client_version
+        tar cvzf prometheus_client-$prometheus_client_version.tar.gz prometheus_client-$prometheus_client_version
+        rpmbuild -ta prometheus_client-$prometheus_client_version.tar.gz
+
         if [ $distribution_architecture == 'x86_64' ]; then
-            rm -Rf $working_directory/build/prometheus
-            mkdir -p $working_directory/build/prometheus
-            cd $working_directory/build/prometheus
 
             cp -a $root_directory/packages/prometheus $working_directory/build/prometheus/prometheus
             mv prometheus prometheus-$prometheus_version

--- a/versions.conf
+++ b/versions.conf
@@ -3,6 +3,7 @@ ipxe_bluebanquise_release=
 ipxe_bluebanquise_logo=T800 # T800, LIGHT, or custom
 
 prometheus_version=2.20.1
+prometheus_client_version=0.8.0
 alertmanager_version=0.21.0
 ipmi_exporter_version=1.3.0
 node_exporter_version=1.0.1


### PR DESCRIPTION
This package was missing, and is used in example custom exporters.